### PR TITLE
DVC-1887 - Add new public key for UniFHIR

### DIFF
--- a/non-production/jwks.json
+++ b/non-production/jwks.json
@@ -15,6 +15,14 @@
              "alg": "RS512",
              "kid": "unifhir-non-prod-1",
              "use": "sig"
+         },
+         {
+           "kty": "RSA",
+           "n": "0ilRV3NyEdoY6J3L16EhZB6_TJzEoXf1H75FFhMbWq1gWwjE1i95AzwrQx9vi1eofCvnUp8bXbK3swRvl43MDXY63a3nun9u_wg755bsmfxmq_Racw6Z25EwfYsedEK6NvgARaSsJ9vOdz18irn4q44EP1rU7IOj382qFpf7ZYXAm0gWwnPEYWZjWZE7Xg-MyJLpwON2aaFzBbZUvFOkfB0at_xjptQYGm4uyAZZyEoxjnSqcMcQiczxloKHJ9kXdOPyfV9VVWvhebH0N087_D_EgmTRu-x2E7eTlnH_5jAqeyhh8bCdzz8PJxuPs2b_HVCSihSaIaeWj8DpwxskDL4DNdSr3FxCRJLbd-j5tiguxgR1qcpIotVRnWFvJcDXo8vOSVPwmDUIDq62yJ19R7JMzZc8yJzxMiAupUsqUuPtGiDKsAuB5yYP-h0d_raL8pEkhH7p9mSjyIN3t9d9AWhqziKQE38BWhxxaV2bDDBls6IWSxAQ1QhFroF2oPh2N80Vb5xqmLfDMyZafSxGICfJIUizjsXm5cy_4eGHeO74Jmyvuo_i44Yd-BV215uGRJZ8HOOFPWmA8d36oP1OqFNnBz2CSI3s-lzQpvlnXOAImpIe3-iZDNTp9ss3ImWEoIgBH_hXUiklq9KkjOEDdsCLUw3ATW09h_QtuIWmbW8",
+           "e": "AQAB",
+           "alg": "RS512",
+           "kid": "unifhir-non-prod-2",
+           "use": "sig"
          }
      ]
  }


### PR DESCRIPTION
# Description

https://doccla.atlassian.net/browse/DVC-1887

Authentication is not currently working using the `unifhir-non-prod-1` key. 
We suspect something is wrong with the key, maybe the public/private keys don't match.

This PR adds another UniFHIR key into the non-prod keyset to test this theory. If this keys works, there will be a followup PR to this to remove the `unifhir-non-prod-1` key and create a new prod one too.

The key pair has been stored in 1password under the label 'unifhir-non-prod-2 identity keys'

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually

Wrote a temporary test using the `buddy/sign` library to verify we can `sign` and `unsign` a JWT using these keys. The test works for `unifhir-non-prod-2` but not for  `unifhir-non-prod-1`.