### PR TITLE
DVC-1979 - Add new production public key for UniFHIR

### DIFF
--- a/production/jwks.json
+++ b/production/jwks.json
@@ -15,6 +15,14 @@
              "alg": "RS512",
              "kid": "unifhir-prod-1",
              "use": "sig"
+         },
+         {
+           "kty": "RSA",
+           "n": "94qreNAp5LuOORDAH2OU0jnaGWnL2-FrBNQhfICdjydVRJVgqd2c20nr0Z9wjVcUTm6kOKEnCcBwAhWtJF77pv_aGewTBSHwlT0t1Q9T2A0ubskrcZ2GLxoOebUVZGBWki88vCOCTj6CQteRx9lQvAdthrrjhDpL1wCiVsBS7jWDsHpV9Hdf3Bf6AuDN04DWq85-ytVZ51mLeDgQsh0cFJv4AU2-ztdb96aqXU_vxR3iwkcto_6XhUY65bbsQQ-GTid6f3v_d1y9HJtJP2yzbDDthEMUFNXe-op1i5vm2m8DRhL7zqX1VspmcZA6uMsr3Ug3EkxLjSNVOb8AhDyjJYITTmwhz95kzexxIWfHtA9gqCbd51XoDGQm5U2KRRppq0TgtoLBROMualwaUp-WgcoDF-2O6krGh8SsjFZjyTtJpXhI9mBZ_1y_BzUJ4nRoIkYG9IFEEIWhSHjiyDL-AAKwkPiu13kTUC9AKx_qI8uOsS3WaWud1q8hxRyntpDW2VXMqpX8uwBNCIXw5EmwP7mfxs0ZsY2RrPevraED4Ygs0TyyfajOK9ChLWmRQKzzNmjDzjGyGIjZQjw9NAOKPJkmnUkwYGEdXLCOb0CNm0mU-kOdewVxqw1vGquiy8hxcsXiKbWvGsj4yki3abv2EqhnjPaJFLEIrAXmHwOz2K8",
+           "e": "AQAB",
+           "alg": "RS512",
+           "kid": "unifhir-prod-2",
+           "use": "sig"
          }
      ]
  }


### PR DESCRIPTION
# Description

https://doccla.atlassian.net/browse/DVC-1979

When testing with MFT (Epic customer) we discovered the non-prod key-pair wasn't working to verify the JWT on their side. After some debugging we just generated a new key (unifhir-non-prod-2) and that worked fine.

This is to also update the prod key so we can have more confidence the keys will work when we get to production too.

There will be an accompanying UniFHIR PR to update the config to use these keys and also the private key GCP secrets will get updated for the new keys.

The keys are stored in the 1password entry 'unifhir-prod-2 identity keys'

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually

Verified the non-prod-2 key works with the MFT test environment from a local stack. This is an identical change for prod so it should work too 🤞 
