### PR TITLE
DVC-4255: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-* @doccla/ehr-integrations
+# See link for details
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+* @doccla/ehr-integrations @doccla/enrol @doccla/backend


### PR DESCRIPTION
https://doccla.atlassian.net/browse/DVC-4255
- update CODEOWNERS to reflect the new vertical teams, and the horizontal tech expertise areas
- per what has been set out in this doc https://docs.google.com/spreadsheets/d/1W5Wt4nTdS2FLQ1SIxi6iVNdsmMh1U6bauZHHyTH7_6o/edit?gid=314766271#gid=314766271
- see also 'how codeowners files works' https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file